### PR TITLE
Todo詳細取得APIの実装

### DIFF
--- a/app/controllers/v1/todo/todos_controller.rb
+++ b/app/controllers/v1/todo/todos_controller.rb
@@ -1,6 +1,10 @@
 class V1::Todo::TodosController < V1::AuthorizationsController
   def index
-    render json: TodosResource.new(current_user.todos.order(:id)).serialize
+    render json: Todo::TodoResource.new(current_user.todos.order(:id)).serialize
+  end
+
+  def show
+    render json: Todo::TodoResource.new(current_user.todos.find(params[:id])).serialize
   end
 
   def create

--- a/app/controllers/v1/users/mes_controller.rb
+++ b/app/controllers/v1/users/mes_controller.rb
@@ -1,5 +1,5 @@
 class V1::Users::MesController < V1::AuthorizationsController
   def show
-    render json: UserMeResource.new(current_user.profile).serialize
+    render json: User::UserMeResource.new(current_user.profile).serialize
   end
 end

--- a/app/resources/todo/todo_resource.rb
+++ b/app/resources/todo/todo_resource.rb
@@ -1,0 +1,3 @@
+class Todo::TodoResource < ApplicationResource
+  attributes :id, :title, :content
+end

--- a/app/resources/todos_resource.rb
+++ b/app/resources/todos_resource.rb
@@ -1,3 +1,0 @@
-class TodosResource < ApplicationResource
-  attributes :title, :content
-end

--- a/app/resources/user/user_me_resource.rb
+++ b/app/resources/user/user_me_resource.rb
@@ -1,4 +1,4 @@
-class UserMeResource < ApplicationResource
+class User::UserMeResource < ApplicationResource
   attributes :nickname, :email, :icon
 
   attribute :icon do |resource|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@
 #                         v1_users_sign_up POST   /v1/users/sign_up(.:format)                                                                       v1/users/sign_ups#create
 #                              v1_users_me GET    /v1/users/me(.:format)                                                                            v1/users/mes#show
 #                                 v1_todos GET    /v1/todos(.:format)                                                                               v1/todo/todos#index
+#                                          POST   /v1/todos(.:format)                                                                               v1/todo/todos#create
+#                                  v1_todo GET    /v1/todos/:id(.:format)                                                                           v1/todo/todos#show
 #            rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format)                                           action_mailbox/ingresses/postmark/inbound_emails#create
 #               rails_relay_inbound_emails POST   /rails/action_mailbox/relay/inbound_emails(.:format)                                              action_mailbox/ingresses/relay/inbound_emails#create
 #            rails_sendgrid_inbound_emails POST   /rails/action_mailbox/sendgrid/inbound_emails(.:format)                                           action_mailbox/ingresses/sendgrid/inbound_emails#create
@@ -31,17 +33,13 @@
 #                     rails_direct_uploads POST   /rails/active_storage/direct_uploads(.:format)                                                    active_storage/direct_uploads#create
 
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
   namespace :v1 do
     namespace :users do
       resource :sign_up, only: :create
       resource :me, only: :show
     end
     scope module: :todo do
-      resources :todos, only: [:index, :create]
+      resources :todos, only: [:index, :show, :create]
     end
   end
 end

--- a/spec/requests/v1/todo/todos_spec.rb
+++ b/spec/requests/v1/todo/todos_spec.rb
@@ -45,6 +45,43 @@ RSpec.describe "V1::Todo::Todos", type: :request do
     end
   end
 
+  describe "GET /v1/todo/todos/:id" do
+    let(:todo) { todos.first }
+
+    context "ログイン済みのユーザの場合" do
+      before do
+        authorization_stub
+        get v1_todo_path(todo.id), headers: headers
+      end
+
+      it "ステータスコードが200であること" do
+        expect(response).to have_http_status(200)
+      end
+
+      it "指定したtodoがJSON形式で返されること" do
+        json = JSON.parse(response.body)
+        expect(json['id']).to eq(todo.id)
+        expect(json['title']).to eq(todo.title)
+        expect(json['content']).to eq(todo.content)
+      end
+    end
+
+    context "ログインしていないユーザの場合" do
+      before do
+        get v1_todo_path(todo.id), headers: headers
+      end
+
+      it "ステータスコードが401であること" do
+        expect(response).to have_http_status(401)
+      end
+
+      it "エラーメッセージがJSON形式で返されること" do
+        json = JSON.parse(response.body)
+        expect(json["message"]).to eq("Unauthorized")
+      end
+    end
+  end
+
   describe "POST /v1/todos" do
     let(:valid_attributes) { attributes_for(:todo) }
     context "ログイン済みのユーザの場合" do
@@ -60,6 +97,21 @@ RSpec.describe "V1::Todo::Todos", type: :request do
         expect(user.todos.count).to eq(4)
         expect(user.todos.last.title).to eq(valid_attributes[:title])
         expect(user.todos.last.content).to eq(valid_attributes[:content])
+      end
+    end
+
+    context "ログインしていないユーザの場合" do
+      before do
+        post v1_todos_path, params: { todo: valid_attributes }.to_json, headers: headers
+      end
+
+      it "ステータスコードが401であること" do
+        expect(response).to have_http_status(401)
+      end
+
+      it "エラーメッセージがJSON形式で返されること" do
+        json = JSON.parse(response.body)
+        expect(json["message"]).to eq("Unauthorized")
       end
     end
   end

--- a/spec/resources/todo/todo_spec.rb
+++ b/spec/resources/todo/todo_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe TodosResource, type: :resource do
+RSpec.describe Todo::TodoResource, type: :resource do
   let!(:user) { create(:user) }
   let!(:todo) { create(:todo, user: user) }
 
@@ -9,6 +9,7 @@ RSpec.describe TodosResource, type: :resource do
   describe "Resourceを使用した場合" do
     context "正常なオブジェクトを作成した場合" do
       it "オブジェクトのプロパティがTodoのプロパティと同じであること" do
+        expect(subject.object.id).to eq(todo.id)
         expect(subject.object.title).to eq(todo.title)
         expect(subject.object.content).to eq(todo.content)
       end

--- a/spec/resources/user/user_me_spec.rb
+++ b/spec/resources/user/user_me_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe UserMeResource, type: :resource do
+RSpec.describe User::UserMeResource, type: :resource do
   let!(:user) { create(:user) }
   let!(:profile) { create(:profile, user: user) }
 


### PR DESCRIPTION
close #54 
- Todo詳細取得API(GET `/v1/todos/:id`)の実装
- リクエストスペックの実装
- ディレクトリの変更