### PR TITLE
Todo削除APIの実装

### DIFF
--- a/app/controllers/v1/todo/todos_controller.rb
+++ b/app/controllers/v1/todo/todos_controller.rb
@@ -13,6 +13,12 @@ class V1::Todo::TodosController < V1::AuthorizationsController
     head :created
   end
 
+  def destroy
+    todo = current_user.todos.find(params[:id])
+    todo.destroy!
+    head :no_content
+  end
+
   private
 
   def todo_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
       resource :me, only: :show
     end
     scope module: :todo do
-      resources :todos, only: [:index, :show, :create]
+      resources :todos, only: [:index, :show, :create, :destroy]
     end
   end
 end

--- a/spec/requests/v1/todo/todos_spec.rb
+++ b/spec/requests/v1/todo/todos_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe "V1::Todo::Todos", type: :request do
   # ログイン済みのユーザ
-  let(:user) { create(:user) }
+  let!(:user) { create(:user) }
   let!(:todos) { create_list(:todo, 3, user: user) }
 
   # ログインしていないユーザ
-  let(:other_user) { create(:user) }
+  let!(:other_user) { create(:user) }
   let!(:other_todos) { create_list(:todo, 2, user: other_user) }
 
   let!(:headers) { { "Content-Type" => "application/json" } }
@@ -46,7 +46,7 @@ RSpec.describe "V1::Todo::Todos", type: :request do
   end
 
   describe "GET /v1/todo/todos/:id" do
-    let(:todo) { todos.first }
+    let!(:todo) { todos.first }
 
     context "ログイン済みのユーザの場合" do
       before do
@@ -83,7 +83,8 @@ RSpec.describe "V1::Todo::Todos", type: :request do
   end
 
   describe "POST /v1/todos" do
-    let(:valid_attributes) { attributes_for(:todo) }
+    let!(:valid_attributes) { attributes_for(:todo) }
+
     context "ログイン済みのユーザの場合" do
       before do
         authorization_stub
@@ -103,6 +104,40 @@ RSpec.describe "V1::Todo::Todos", type: :request do
     context "ログインしていないユーザの場合" do
       before do
         post v1_todos_path, params: { todo: valid_attributes }.to_json, headers: headers
+      end
+
+      it "ステータスコードが401であること" do
+        expect(response).to have_http_status(401)
+      end
+
+      it "エラーメッセージがJSON形式で返されること" do
+        json = JSON.parse(response.body)
+        expect(json["message"]).to eq("Unauthorized")
+      end
+    end
+  end
+
+  describe "DELETE /v1/todo/todos/:id" do
+    let!(:todo) { todos.first }
+
+    context "ログイン済みのユーザの場合" do
+      before do
+        authorization_stub
+        delete v1_todo_path(todo.id), headers: headers
+      end
+
+      it "ステータスコードが204であること" do
+        expect(response).to have_http_status(204)
+      end
+
+      it "指定したtodoが削除されること" do
+        expect { Todo.find(todo.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "ログインしていないユーザの場合" do
+      before do
+        delete v1_todo_path(todo.id), headers: headers
       end
 
       it "ステータスコードが401であること" do


### PR DESCRIPTION
close #60 
- Todo削除API(DELETE `/v1/todos/:id`)の実装
- テストコードの実装